### PR TITLE
chore: migrate chain id

### DIFF
--- a/configs/network/v2/genesis.json
+++ b/configs/network/v2/genesis.json
@@ -1,25 +1,25 @@
 {
-  "chain_id": "tn-v2",
-  "initial_height": 148618,
-  "db_owner": "0xEC36224A679218Ae28FCeCe8d3c68595B87Dd832",
-  "validators": [
-    {
-      "pubkey": "4e0b5c952be7f26698dc1898ff3696ac30e990f25891aeaf88b0285eab4663e1",
+    "chain_id": "tn-v2.1",
+    "initial_height": 195391,
+    "db_owner": "0xEC36224A679218Ae28FCeCe8d3c68595B87Dd832",
+    "validators": [
+      {
+        "pubkey": "0c830b69790eaa09315826403c2008edc65b5c7132be9d4b7b4da825c2a166ae",
+        "type": "ed25519",
+        "power": 1
+      }
+    ],
+    "state_hash": "e4c6e9961abc32c3c0ad0c6789d39dbba08d6641223113cadf65773a0b247005",
+    "migration": {
+      "start_height": 0,
+      "end_height": 0
+    },
+    "leader": {
       "type": "ed25519",
-      "power": 1
-    }
-  ],
-  "state_hash": "ca2d33954aac9a05cb880cf7a885dfe7dc8d5b368897e80ed8025ab73e342ced",
-  "migration": {
-    "start_height": 0,
-    "end_height": 0
-  },
-  "leader": {
-    "type": "ed25519",
-    "key": "4e0b5c952be7f26698dc1898ff3696ac30e990f25891aeaf88b0285eab4663e1"
-  },
-  "max_block_size": 6291456,
-  "join_expiry": "168h0m0s",
-  "disabled_gas_costs": true,
-  "max_votes_per_tx": 200
-}
+      "key": "0c830b69790eaa09315826403c2008edc65b5c7132be9d4b7b4da825c2a166ae"
+    },
+    "max_block_size": 6291456,
+    "join_expiry": "168h0m0s",
+    "disabled_gas_costs": true,
+    "max_votes_per_tx": 200
+  }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above by following our Developer Guidelines -->

## Description
<!--- Describe your changes in detail; use bullet points. -->

## Related Problem
<!--- If this pull request relates to an existing Problem, please link to it here (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) -->
<!-- example: 

resolves: #112330

-->

related to https://github.com/trufnetwork/truf-node-operator/issues/67#issuecomment-3174413375

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated network genesis to tn-v2.1 with new chain_id and initial_height.
  - Introduced a new single ed25519 validator and aligned leader reference.
  - Refreshed state hash.
  - Migration block unchanged (start_height: 0, end_height: 0).
  - Retained parameters: db_owner, max_block_size (6291456), join_expiry (168h0m0s), disabled_gas_costs (true), max_votes_per_tx (200).
  - Impact: Clients must use the updated genesis and validator key to connect; a resync may be required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->